### PR TITLE
Add application/json content type header to push replication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,10 @@ export function replicateOrion<RxDocType>({
       const result = await executePull({
         url,
         collection,
-        headers,
+        headers: {
+          ...headers,
+          'Content-Type': 'application/json',
+        },
         params,
         batchSize,
         wrap,


### PR DESCRIPTION
Not sure if it's the best solution, but I needed to add this for push replication to work. Thoughts?